### PR TITLE
Add write_csv_robust to prevent write.csv from failing with list-columns

### DIFF
--- a/inst/shiny/funcs/functions.R
+++ b/inst/shiny/funcs/functions.R
@@ -547,3 +547,21 @@ printVecAsis <- function(x) {
     }
   }
 }
+
+#####################
+# Download utlities #
+#####################
+
+convert_list_cols <- function(x) {
+  dplyr::mutate_if(.tbl = x,
+                   .predicate = function(col) inherits(col, "list"),
+                   .funs = function(col) {
+                     vapply(col,
+                            jsonlite::toJSON,
+                            character(1L))
+                   })
+}
+
+write_csv_robust <- function(x, ...) {
+  write.csv(convert_list_cols(x), ...)
+}

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -219,7 +219,7 @@ shinyServer(function(input, output, session) {
   output$dlDbOccs <- downloadHandler(
     filename = function() {paste0(formatSpName(spName()), '_original_', rvs$occDb, ".csv")},
     content = function(file) {
-      write.csv(rvs$occsOrig, file, row.names=FALSE)
+      write_csv_robust(rvs$occsOrig, file, row.names=FALSE)
     }
   )
   
@@ -287,7 +287,7 @@ shinyServer(function(input, output, session) {
     content = function(file) {
       # thinned_rowNums <- as.numeric(thinOccs()$occID)
       # origThinned <- rvs$occsOrig[thinned_rowNums,]
-      write.csv(rvs$occs %>% dplyr::select(-pop), file, row.names = FALSE)
+      write_csv_robust(rvs$occs %>% dplyr::select(-pop), file, row.names = FALSE)
     }
   )
   
@@ -486,7 +486,7 @@ shinyServer(function(input, output, session) {
       occs.bg.bind <-rbind(rvs$occs[,1:3], bg.bind)
       all.bind <- cbind(occs.bg.bind, c(rvs$occsGrp, rvs$bgGrp))
       names(all.bind)[4] <- "group"
-      write.csv(all.bind, file, row.names = FALSE)
+      write_csv_robust(all.bind, file, row.names = FALSE)
     }
   )
   
@@ -591,7 +591,7 @@ shinyServer(function(input, output, session) {
       }
     },
     content = function(file) {
-      write.csv(rvs$modRes, file, row.names = FALSE)
+      write_csv_robust(rvs$modRes, file, row.names = FALSE)
     }
   )
   


### PR DESCRIPTION
I've added `write_csv_robust()` to `inst/shiny/funcs/function.R` and replaced all instances of `write.csv()` in `userReport.Rmd`.   This addresses #145.

I'm currently working on a remote server and haven't been able to get the testing workflow going correctly.