### PR TITLE
Avoid changing paths in Mask download function

### DIFF
--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -430,7 +430,6 @@ shinyServer(function(input, output, session) {
     filename = function() {'mskEnvs.zip'},
     content = function(file) {
       tmpdir <- tempdir()
-      setwd(tempdir())
       type <- input$bgMskFileType
       nm <- names(rvs$bgMsk)
       
@@ -438,9 +437,9 @@ shinyServer(function(input, output, session) {
                           suffix = nm, format = type, overwrite = TRUE)
       ext <- switch(type, raster = 'grd', ascii = 'asc', GTiff = 'tif')
       
-      fs <- paste0('msk_', nm, '.', ext)
+      fs <- file.path(tmpdir, paste0('msk_', nm, '.', ext))
       if (ext == 'grd') {
-        fs <- c(fs, paste0('msk_', nm, '.gri'))
+        fs <- c(fs, file.path(tmpdir, paste0('msk_', nm, '.gri')))
       }
       zip(zipfile=file, files=fs)
       if (file.exists(paste0(file, ".zip"))) {file.rename(paste0(file, ".zip"), file)}


### PR DESCRIPTION
This PR addresses #144.  In the previous code, the download handler for masked environmental data changed the R session working directory to a temp directory without changing it back, leading to cascading errors in other operations, including downloading the session `Rmd` file.  

The fleeting nature of the error in #144 seems to have been due to the fact that it only occurs after you download the masked environmental variables. If you move on without downloading these, then the `Rmd` downloads fine.

I had some issues with `on.exit` in this context, so I just avoid changing the working directory entirely include the temp directory in all file paths.

@shirleyxchen, please test this after installing `noamross/wallce@fix-mask-workdirs`.