### PR TITLE
More robust cross-platform zip downloads

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Maintainer: Jamie M. Kass <jkass@gradcenter.cuny.edu>
 Depends: R (>= 3.2.1), shiny (>= 0.14.2), leaflet (>= 1.0.1)
 Imports: DT (>= 0.2), shinyjs, spocc (>= 0.5.4), RColorBrewer, dplyr,
         spThin, ENMeval, rgeos, maptools, dismo, raster, shinythemes,
-        magrittr, rgdal, leaflet.extras, XML, rmarkdown, testthat
+        magrittr, rgdal, leaflet.extras, XML, rmarkdown, testthat, zip
 Description: The 'shiny' application 'wallace' is a modular platform for reproducible modeling of species niches and distributions. 'wallace' guides users through a complete analysis, from the acquisition of species occurrence and environmental data to visualizing model predictions on an interactive map, thus bundling complex workflows into a single, streamlined interface.
 License: GPL-3
 URL: https://wallaceEcoMod.github.io

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -430,6 +430,8 @@ shinyServer(function(input, output, session) {
     filename = function() {'mskEnvs.zip'},
     content = function(file) {
       tmpdir <- tempdir()
+      owd <- setwd(tmpdir)
+      on.exit(setwd(owd))
       type <- input$bgMskFileType
       nm <- names(rvs$bgMsk)
       
@@ -437,9 +439,9 @@ shinyServer(function(input, output, session) {
                           suffix = nm, format = type, overwrite = TRUE)
       ext <- switch(type, raster = 'grd', ascii = 'asc', GTiff = 'tif')
       
-      fs <- file.path(tmpdir, paste0('msk_', nm, '.', ext))
+      fs <- paste0('msk_', nm, '.', ext)
       if (ext == 'grd') {
-        fs <- c(fs, file.path(tmpdir, paste0('msk_', nm, '.gri')))
+        fs <- c(fs, paste0('msk_', nm, '.gri'))
       }
       zip(zipfile=file, files=fs)
       if (file.exists(paste0(file, ".zip"))) {file.rename(paste0(file, ".zip"), file)}

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -443,7 +443,7 @@ shinyServer(function(input, output, session) {
       if (ext == 'grd') {
         fs <- c(fs, paste0('msk_', nm, '.gri'))
       }
-      zip(zipfile=file, files=fs)
+      zip::zip(zipfile=file, files=fs)
       if (file.exists(paste0(file, ".zip"))) {file.rename(paste0(file, ".zip"), file)}
     },
     contentType = "application/zip"
@@ -698,9 +698,10 @@ shinyServer(function(input, output, session) {
   # download for model predictions (restricted to background extent)
   output$dlPred <- downloadHandler(
     filename = function() {
-      ext <- switch(input$predFileType, raster = 'grd', ascii = 'asc', GTiff = 'tif', png = 'png')
+      ext <- switch(input$predFileType, raster = 'zip', ascii = 'asc', GTiff = 'tif', png = 'png')
       paste0(names(rvs$predCur), '.', ext)},
     content = function(file) {
+      browser()
       if (require(rgdal)) {
         if (input$predFileType == 'png') {
           png(file)
@@ -710,8 +711,10 @@ shinyServer(function(input, output, session) {
           fileName <- names(rvs$predCur)
           tmpdir <- tempdir()
           raster::writeRaster(rvs$predCur, file.path(tmpdir, fileName), format = input$predFileType, overwrite = TRUE)
-          fs <- file.path(tmpdir, paste0(fileName, c('.grd', '.gri')))
-          zip(zipfile=file, files=fs, extras = '-j')
+          owd <- setwd(tmpdir)
+          fs <- paste0(fileName, c('.grd', '.gri'))
+          zip::zip(zipfile=file, files=fs)
+          setwd(owd)
         } else {
           r <- raster::writeRaster(rvs$predCur, file, format = input$predFileType, overwrite = TRUE)
           file.rename(r@file@name, file)
@@ -815,7 +818,7 @@ shinyServer(function(input, output, session) {
   # download for model predictions (restricted to background extent)
   output$dlProj <- downloadHandler(
     filename = function() {
-      ext <- switch(input$projFileType, raster = 'grd', ascii = 'asc', GTiff = 'tif', PNG = 'png')
+      ext <- switch(input$projFileType, raster = 'zip', ascii = 'asc', GTiff = 'tif', PNG = 'png')
       paste0(names(rvs$projCur), '.', ext)},
     content = function(file) {
       if (require(rgdal)) {
@@ -827,8 +830,10 @@ shinyServer(function(input, output, session) {
           fileName <- names(rvs$projCur)
           tmpdir <- tempdir()
           raster::writeRaster(rvs$projCur, file.path(tmpdir, fileName), format = input$projFileType, overwrite = TRUE)
-          fs <- file.path(tmpdir, paste0(fileName, c('.grd', '.gri')))
-          zip(zipfile=file, files=fs, extras = '-j')
+          owd <- setwd(tmpdir)
+          fs <- paste0(fileName, c('.grd', '.gri'))
+          zip::zip(zipfile=file, files=fs)
+          setwd(owd)
         } else {
           r <- raster::writeRaster(rvs$projCur, file, format = input$projFileType, overwrite = TRUE)
           file.rename(r@file@name, file)


### PR DESCRIPTION
We were having some issues with downloading processed environmental data and model exports on Windows that I traced to cross-platform issues with `utils::zip()`.  Since `utils::zip()` calls out to the local system `zip` program, it can have slightly different behaviors depending on the platform and versions installed.  However the R **zip** package has an internal implementation which means identical behavior across platforms.  This PR adds **zip** as a dependency and uses it for all `zip()` calls.  

Also, for model predictions and projections there was a bug where saving as type `'raster'` would only return the `.grd` file, not the zipped `.grd` and `.gri` files. This PR Fixes that.

This builds on top of #147 and its amendment so if you merge this in there's no need to revert that.  We've already tested this one 😉  

cc @shirleyxchen