### PR TITLE
Adding a couple convenience functions for running wallace  headless

### DIFF
--- a/R/run_wallace.R
+++ b/R/run_wallace.R
@@ -11,7 +11,7 @@
 #' }
 #'
 #' @export
-run_wallace <- function(){
+run_wallace <- function(launch.browser = TRUE, port = getOption("shiny.port")){
   app_path <- system.file("shiny", package = "wallace")
-  return(shiny::runApp(app_path, launch.browser = TRUE))
+  return(shiny::runApp(app_path, launch.browser = launch.browser, port = port))
 }

--- a/man/run_wallace.Rd
+++ b/man/run_wallace.Rd
@@ -4,7 +4,12 @@
 \alias{run_wallace}
 \title{Run \emph{Wallace} Application}
 \usage{
-run_wallace()
+run_wallace(launch.browser=TRUE, port=NA)
+}
+\arguments{
+  \item{launch.browser}{Whether or not to launch a new browser window.}
+
+  \item{port}{The port for the shiny server to listen on. Defaults to a random available port.}
 }
 \description{
 This function runs the \emph{Wallace} application in the user's default web browser.


### PR DESCRIPTION
Adding 2 convenience arguments for run_wallace()

* `launch.browser` defaults to TRUE, but FALSE does not launch the browser locally.
* `port` defaults to random, but can be specified as any unallocated port number.

Updated the man page too.