### PR TITLE
Added `occs.sel` to the return() in the `poccs_selectOccs` function. …

### DIFF
--- a/R/poccs_selectOccs.R
+++ b/R/poccs_selectOccs.R
@@ -1,6 +1,6 @@
 # Wallace EcoMod: a flexible platform for reproducible modeling of
 # species niches and distributions.
-# 
+#
 # poccs_selectOccs.R
 # File author: Wallace EcoMod Dev Team. 2023.
 # --------------------------------------------------------------------------
@@ -98,7 +98,7 @@ poccs_selectOccs <- function(occs, polySelXY, polySelID = 1, logger = NULL,
         hlSpp(spN),
         "Your polygon is selecting all occurrences. None will be removed.")
       occs.sel <- occs
-      return()
+      return(occs.sel)
     }
     occs.sel <- occs[-ptRemIndex,]
 


### PR DESCRIPTION
…Without this, the function returns NULL in some circumstances in the Rmd code generated from a session.

In the case where a selection polygon includes all of the possible points, this function should return the original occurrence object. It doesn't currently do this (at least when running the analysis using the generated Rmd file), because for this `if` scenario, the `return` function doesn't include the `occs.sel` object. So currently, the function returns NULL in this case.